### PR TITLE
Add weeknightly supply chain review, starting with pre-commit pins

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,0 +1,38 @@
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to Title 17 Section 105 of the
+# United States Code, this software is not subject to copyright
+# protection within the United States. NIST assumes no responsibility
+# whatsoever for its use by other parties, and makes no guarantees,
+# expressed or implied, about its quality, reliability, or any other
+# characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+# This workflow uses Make to review direct dependencies of this
+# repository.
+
+name: Supply Chain
+
+on:
+  schedule:
+    - cron: '15 5 * * 1,2,3,4,5'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - '3.9'
+          - '3.13'
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Review dependencies
+      run: make check-supply-chain

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ all: \
 
 .PHONY: \
   check-docs \
+  check-supply-chain \
+  check-supply-chain-pre-commit \
   docs \
   docs-figs \
   docs-tests
@@ -78,6 +80,40 @@ check-docs-tests:
 	  PYTHON3=$(PYTHON3) \
 	  --directory tests \
 	  check-docs
+
+check-supply-chain: \
+  check-supply-chain-pre-commit
+
+# Update pre-commit configuration and use the updated config file to
+# review code.  Only have Make exit if 'pre-commit run' modifies files.
+check-supply-chain-pre-commit: \
+  .venv-pre-commit/var/.pre-commit-built.log
+	source .venv-pre-commit/bin/activate \
+	  && pre-commit autoupdate
+	git diff \
+	  --exit-code \
+	  .pre-commit-config.yaml \
+	  || ( \
+	      source .venv-pre-commit/bin/activate \
+	        && pre-commit run \
+	          --all-files \
+	          --config .pre-commit-config.yaml \
+	    ) \
+	    || git diff \
+	      --exit-code \
+	      --stat \
+	      || ( \
+	          echo \
+	            "WARNING:Makefile:pre-commit configuration can be updated.  It appears the update would change file formatting." \
+	            >&2 \
+	            ; exit 1 \
+                )
+	@git diff \
+	  --exit-code \
+	  .pre-commit-config.yaml \
+	  || echo \
+	    "INFO:Makefile:pre-commit configuration can be updated.  It appears the update would not change file formatting." \
+	    >&2
 
 clean:
 	@$(MAKE) --directory figs clean


### PR DESCRIPTION
Source: This code has been trialed throughout several repositories in the Cyber Domain Ontology.  I can't currently recall the original repository where this logic was deployed, but this state of the code was copied with a few typo fixes from CASE-Corpora.


## References

* https://github.com/casework/CASE-Corpora


## Disclaimer

Participation by NIST in the creation of the documentation of mentioned software is not intended to imply a recommendation or endorsement by the National Institute of Standards and Technology, nor is it intended to imply that any specific software is necessarily the best available for the purpose.